### PR TITLE
Merge dependencies to dsBase only

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: datashield
 Maintainer: <datashield@obiba.org>
 Author: <datashield@obiba.org>
-Version: 3.0.1
+Version: 5.0.0
 License: GPL-3
 Title: Datashield meta-package (server side)
 Description: This package installs as dependencies all other DataSHIELD packages for server side.
-Depends: nlme, dsBase, dsModelling, dsGraphics, dsStats
+Depends: dsBase


### PR DESCRIPTION
`datashield` is a meta-package which purpose was originally to install all DS server packages in a single command, which is very convenient when executed from Opal's datashield administration page. Now that all DS packages have been merged into `dsBase`, this PR is for backward compatibility.